### PR TITLE
Correcting path of imscmservice to new location

### DIFF
--- a/msm8916-common/Android.mk
+++ b/msm8916-common/Android.mk
@@ -114,7 +114,7 @@ include $(BUILD_PREBUILT)
 include $(CLEAR_VARS)
 LOCAL_MODULE := com.qualcomm.qti.imscmservice@1.0-java
 LOCAL_MODULE_OWNER := motorola
-LOCAL_SRC_FILES := proprietary/framework/com.qualcomm.qti.imscmservice@1.0-java.jar
+LOCAL_SRC_FILES := proprietary/vendor/framework/com.qualcomm.qti.imscmservice@1.0-java.jar
 LOCAL_CERTIFICATE := platform
 LOCAL_MODULE_TAGS := optional
 LOCAL_MODULE_CLASS := JAVA_LIBRARIES


### PR DESCRIPTION
During build the file can't be found after moving some files to a separate vendor directory.
Correcting this path has probably been missing while working on this commit:
https://github.com/MOTO-M8916/vendor_motorola/commit/13c8ca614b850718e65cb045d357a861a796076a

-----------------
Related to: https://github.com/MOTO-M8916/device_motorola_msm8916-common/issues/2

Signed-off-by: Thomas Karl Pietrowski <thopiekar@gmail.com> (github: thopiekar)